### PR TITLE
disable the posthog telemetry mechnism that may raise the connection error

### DIFF
--- a/coagent/db_handler/vector_db_handler/chroma_handler.py
+++ b/coagent/db_handler/vector_db_handler/chroma_handler.py
@@ -16,7 +16,11 @@ class ChromaHandler:
         @param path: path of data
         @collection_name: name of collection
         '''
-        self.client = chromadb.PersistentClient(path)
+        settings = chromadb.get_settings()
+        # disable the posthog telemetry mechnism that may raise the connection error, such as
+        # "requests.exceptions.ConnectTimeout: HTTPSConnectionPool(host='us-api.i.posthog.com', port 443)"
+        settings.anonymized_telemetry = False
+        self.client = chromadb.PersistentClient(path, settings)
         self.client.heartbeat()
 
         if collection_name:


### PR DESCRIPTION
The telemetry of posthog which used by chromadb is not necessary for ourself, so disable it explicitly to reduce the connection error in some network.

The connection error like this:
![image](https://github.com/codefuse-ai/codefuse-chatbot/assets/196561/c9fb36f4-3a3f-4bcf-891b-0dd409e621d6)